### PR TITLE
package.json version incomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-2-mini",
-  "version": "1",
+  "version": "1.0.0",
   "scripts": {
     "dev": "live-server ./"
   },


### PR DESCRIPTION
students could not npm install without modifying the version.  It is now up to date.